### PR TITLE
Version 2.0.1: Preserve custom fonts set by style attributes

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -61,7 +61,7 @@ const applyCustomFontStyles = () =>
   const newStyleTag = createNewStyleTag(fontFamilyRules);
 
   // Completely rewrite the overriden styles, if applicable.
-  if (existingSheet != null) {
+  if (existingSheet) {
     existingSheet.parentNode.removeChild(existingSheet);
   }
 
@@ -71,14 +71,38 @@ const applyCustomFontStyles = () =>
   document.head.appendChild(newStyleTag);
 };
 
-// Observe the document for dynamically added elements
+const preserveCustomFonts = (element) => {
+  if (element == undefined)
+    return;
+
+  const inlineStyle = element.getAttribute('style');
+  if (!inlineStyle || !inlineStyle.includes('font-family'))
+    return;
+
+  // Font family regex matching the font (group 1) and the !important modifier (group 2).
+  const fontFamilyRegex = /font-family\s*:\s*([^;]+?)(\s*!important)?\s*(;|$)/;
+  const match = fontFamilyRegex.exec(inlineStyle);
+    
+  // Cancel if the style does not contain any font-family property.
+  if (!match)
+    return;
+
+  const hasIsImportant = match[2] && match[2].includes('!important');
+  if (hasIsImportant)
+    return;
+
+  const currentFontFamily = match[1].trim();
+  element.style.setProperty('font-family', currentFontFamily, 'important');
+}
+
+// Observe the document for dynamically added styles
 let lastStyleSheets = new Set(Array.from(document.styleSheets).map(sheet => sheet.href || sheet.ownerNode.textContent));
 const observer = new MutationObserver((mutations) => 
 {
   let stylesheetChanged = false;
 
   mutations.forEach(mutation => 
-  {  
+  {
     // Only focus on <link> and <style> elements.
     mutation.addedNodes.forEach(node => 
     {
@@ -87,7 +111,6 @@ const observer = new MutationObserver((mutations) =>
 
       const isStylesheet = node.nodeName === 'LINK' && node.rel === 'stylesheet';
       const isStyleNode = node.nodeName === 'STYLE'
-
       if (!isStylesheet && !isStyleNode)
         return;
 
@@ -103,6 +126,9 @@ const observer = new MutationObserver((mutations) =>
   if (stylesheetChanged) {
     applyCustomFontStyles();
   }
+
+  // Preserve font families set using the style attribute on any HTML element.
+  document.querySelectorAll('*').forEach(preserveCustomFonts);
 });
 
 // Observe the children of the document DOM-element and every newly added element

--- a/src/content.js
+++ b/src/content.js
@@ -71,7 +71,8 @@ const applyCustomFontStyles = () =>
   document.head.appendChild(newStyleTag);
 };
 
-const preserveCustomFonts = (element) => {
+const preserveCustomFonts = (element) => 
+{
   if (element == undefined)
     return;
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "name": "Country Flag Fixer",
     "default_locale": "en",
     "description": "__MSG_extDesc__",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "manifest_version": 3,
     "content_scripts": [
         {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-country-flags",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Replaces mysterious abbreviations automatically with the corresponding flag. The solution for Chromium users on Windows!",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes issue #4 where icons set using the `style` attribute were overwritten by the custom CSS created by the extension. The described issue is rare, as each individual icon has inline styles applied to it. Normally icon libraries will use common CSS.

Version 2.0.1 will additionally iterate over **each** (mutated) DOM element to check if there are any `style` attributes present with a `font-family` property. If so: it will append `!important` to override the font-family set/modified by the extention. This may seem heavy, but all non relevant elements are skipped.